### PR TITLE
Add link to proceedings of 2024 conference

### DIFF
--- a/_posts/2024-10-14-namug2024.markdown
+++ b/_posts/2024-10-14-namug2024.markdown
@@ -5,4 +5,5 @@ date: 2024-10-14
 date-end: 2024-10-16
 external: true
 external-url: https://modelica.org/events/american2024/
+proceedings: https://doi.org/10.3384/ecp207
 ---


### PR DESCRIPTION
This adds a link to the proceedings on https://namug.org/